### PR TITLE
Fix "Bundle-Vendor" key

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.provider.filetransfer.httpclient5;singleton:=true
 Bundle-Version: 1.0.300.qualifier
-Bundle-Vendor: %plugin.vendor
+Bundle-Vendor: %plugin.provider
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.ecf.provider.filetransfer.httpclient5
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
[In `plugin.properties` the key for `Bundle-Vendor` is `plugin.provider`, not `plugin.vendor`](https://github.com/eclipse/ecf/blob/9423e1a3cdc9ae9d21d1e681736f0bc01b34c662/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/plugin.properties#L11)