### PR TITLE
Fix for ECF issue-26:  https://github.com/eclipse/ecf/issues/26

### DIFF
--- a/framework/bundles/org.eclipse.ecf.ssl/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf.ssl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.ssl
 Automatic-Module-Name: org.eclipse.ecf.ssl
-Bundle-Version: 1.2.401.qualifier
+Bundle-Version: 1.2.500.qualifier
 Fragment-Host: org.eclipse.ecf
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: javax.net,

--- a/framework/bundles/org.eclipse.ecf.ssl/pom.xml
+++ b/framework/bundles/org.eclipse.ecf.ssl/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.ecf</groupId>
   <artifactId>org.eclipse.ecf.ssl</artifactId>
-  <version>1.2.401-SNAPSHOT</version>
+  <version>1.2.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/bundles/org.eclipse.ecf.ssl/src/org/eclipse/ecf/internal/ssl/SSLContextHelper.java
+++ b/framework/bundles/org.eclipse.ecf.ssl/src/org/eclipse/ecf/internal/ssl/SSLContextHelper.java
@@ -17,7 +17,7 @@ import javax.net.ssl.TrustManager;
 public class SSLContextHelper {
 
 	private static final String[] jreProtocols = new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.2", "TLSv1.1", "TLSv1",
-			"TLSv1.3", "SSLv3" };
+			"SSLv3" };
 
 	public static SSLContext getSSLContext(String protocols) {
 		SSLContext resultContext = null;

--- a/framework/bundles/org.eclipse.ecf.ssl/src/org/eclipse/ecf/internal/ssl/SSLContextHelper.java
+++ b/framework/bundles/org.eclipse.ecf.ssl/src/org/eclipse/ecf/internal/ssl/SSLContextHelper.java
@@ -16,7 +16,8 @@ import javax.net.ssl.TrustManager;
 
 public class SSLContextHelper {
 
-	private static final String[] jreProtocols = new String[] { "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3" };
+	private static final String[] jreProtocols = new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.2", "TLSv1.1", "TLSv1",
+			"TLSv1.3", "SSLv3" };
 
 	public static SSLContext getSSLContext(String protocols) {
 		SSLContext resultContext = null;

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.provider.filetransfer.httpclient5;singleton:=true
-Bundle-Version: 1.0.401.qualifier
+Bundle-Version: 1.0.500.qualifier
 Bundle-Vendor: %plugin.provider
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.ecf.provider.filetransfer.httpclient5

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/pom.xml
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.provider.filetransfer.httpclient5</artifactId>
-  <version>1.0.401-SNAPSHOT</version>
+  <version>1.0.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
      <build>

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/HttpClientDefaultSSLSocketFactoryModifier.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/HttpClientDefaultSSLSocketFactoryModifier.java
@@ -30,7 +30,7 @@ public class HttpClientDefaultSSLSocketFactoryModifier {
 
 	private String defaultProtocolNames = System.getProperty(DEFAULT_SSL_PROTOCOL);
 
-	private static final String[] jreProtocols = new String[] {"TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	private static final String[] jreProtocols = new String[] {"TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
 	public HttpClientDefaultSSLSocketFactoryModifier() {
 		// empty

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.provider.filetransfer.httpclientjava;singleton:=true
-Bundle-Version: 1.0.300.qualifier
+Bundle-Version: 1.0.400.qualifier
 Bundle-Vendor: %plugin.provider
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.ecf.provider.filetransfer.httpclientjava

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/pom.xml
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.provider.filetransfer.httpclientjava</artifactId>
-  <version>1.0.300-SNAPSHOT</version>
+  <version>1.0.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
      <build>

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/internal/provider/filetransfer/httpclientjava/HttpClientDefaultSSLSocketFactoryModifier.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/internal/provider/filetransfer/httpclientjava/HttpClientDefaultSSLSocketFactoryModifier.java
@@ -30,7 +30,7 @@ public class HttpClientDefaultSSLSocketFactoryModifier {
 
 	private String defaultProtocolNames = System.getProperty(DEFAULT_SSL_PROTOCOL);
 
-	private static final String[] jreProtocols = new String[] {"TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	private static final String[] jreProtocols = new String[] {"TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
 	public HttpClientDefaultSSLSocketFactoryModifier() {
 		// empty


### PR DESCRIPTION
Adds the TLSv1.3 to the jresupported list of https protocols.  Note that TLSv1.3 is only supported on java8u261 b12 or newer)