### PR TITLE
Allow http proxy authentication with SPNEGO on Windows

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/OSGI-INF/services/org.eclipse.ecf.internal.provider.filetransfer.httpclient5.win32.Win32HttpClientConfigurationModifier.xml
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/OSGI-INF/services/org.eclipse.ecf.internal.provider.filetransfer.httpclient5.win32.Win32HttpClientConfigurationModifier.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.ecf.internal.provider.filetransfer.httpclient5.win32.Win32HttpClientConfigurationModifier">
+   <service>
+      <provide interface="org.eclipse.ecf.internal.provider.filetransfer.httpclient5.IHttpClientModifier"/>
+   </service>
    <implementation class="org.eclipse.ecf.internal.provider.filetransfer.httpclient5.win32.Win32HttpClientConfigurationModifier"/>
 </scr:component>

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/win32/Win32HttpClientConfigurationModifier.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/win32/Win32HttpClientConfigurationModifier.java
@@ -26,6 +26,7 @@ import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.eclipse.ecf.internal.provider.filetransfer.httpclient5.HttpClientModifierAdapter;
+import org.eclipse.ecf.internal.provider.filetransfer.httpclient5.IHttpClientModifier;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -33,7 +34,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 // Note that this depends upon HttpClientContext class which is from org.apache.httpcomponents.client5.httpclient5 bundle
-@Component
+@Component(service = { IHttpClientModifier.class })
 public class Win32HttpClientConfigurationModifier extends HttpClientModifierAdapter {
 
 	public static final String ID = "org.eclipse.ecf.provider.filetransfer.httpclients5.win32"; //$NON-NLS-1$

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/ECFHttpClientFactory.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/src/org/eclipse/ecf/internal/provider/filetransfer/httpclient5/ECFHttpClientFactory.java
@@ -60,7 +60,7 @@ import org.apache.hc.core5.pool.PoolReusePolicy;
 @Component
 public class ECFHttpClientFactory implements IHttpClientFactory {
 	private static final List<String> DEFAULT_PREFERRED_AUTH_SCHEMES_NO_NTLM = Arrays.asList("Basic","Digest");
-	private static final List<String> DEFAULT_PREFERRED_AUTH_SCHEMES = Arrays.asList("Basic", "Digest", "NTLM");
+	private static final List<String> DEFAULT_PREFERRED_AUTH_SCHEMES = Arrays.asList("Basic", "Digest", "NTLM", "Negotiate");
 	public static final int DEFAULT_CONNECTION_TIMEOUT = HttpClientOptions.RETRIEVE_DEFAULT_CONNECTION_TIMEOUT;
 	public static final int DEFAULT_CONNECTION_TTL = HttpClientOptions.RETRIEVE_DEFAULT_CONNECTION_TTL;
 	public static final int DEFAULT_READ_TIMEOUT = HttpClientOptions.RETRIEVE_DEFAULT_READ_TIMEOUT;


### PR DESCRIPTION
Nowadays companies often use proxy servers for malware detection. Sometimes these servers need authentication (HTTP status code 407 _Proxy Authentication Required_).

The direct use of NTLM authentication is now commonly replaced with SPNEGO (RFC 4559) to negotiate an authentication scheme (e.g. Kerberos or NTLM). In order to handle the response header _Proxy-Authenticate: Negotiate_, this scheme has to be added to the list of preferred authentication schemes including NTLM.

In addition, the `Win32HttpClientConfigurationModifier` has to be registered as a service implementation for `IHttpClientModifier` in order to be found in `Activator.getModifierReferences()`.