### PR TITLE
Register protocol handlers in a lazy fashion

### DIFF
--- a/framework/bundles/org.eclipse.ecf.filetransfer/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf.filetransfer/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.filetransfer;singleton:=true
 Automatic-Module-Name: org.eclipse.ecf.filetransfer
-Bundle-Version: 5.1.102.qualifier
+Bundle-Version: 5.1.103.qualifier
 Bundle-Activator: org.eclipse.ecf.internal.filetransfer.Activator
 Bundle-Vendor: %plugin.provider
 Eclipse-LazyStart: true

--- a/framework/bundles/org.eclipse.ecf.filetransfer/pom.xml
+++ b/framework/bundles/org.eclipse.ecf.filetransfer/pom.xml
@@ -9,6 +9,6 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.filetransfer</artifactId>
-  <version>5.1.102-SNAPSHOT</version>
+  <version>5.1.103-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/bundles/org.eclipse.ecf.filetransfer/src/org/eclipse/ecf/internal/filetransfer/Activator.java
+++ b/framework/bundles/org.eclipse.ecf.filetransfer/src/org/eclipse/ecf/internal/filetransfer/Activator.java
@@ -17,7 +17,8 @@ import org.eclipse.ecf.core.util.LogHelper;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.log.LogService;
-import org.osgi.service.url.*;
+import org.osgi.service.url.URLConstants;
+import org.osgi.service.url.URLStreamHandlerService;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -32,8 +33,6 @@ public class Activator implements BundleActivator {
 			+ "urlStreamHandlerService"; //$NON-NLS-1$
 
 	private static final String PROTOCOL_ATTRIBUTE = "protocol"; //$NON-NLS-1$
-
-	private static final String SERVICE_CLASS_ATTRIBUTE = "serviceClass"; //$NON-NLS-1$
 
 	private ServiceTracker extensionRegistryTracker = null;
 
@@ -95,18 +94,11 @@ public class Activator implements BundleActivator {
 			IConfigurationElement[] configurationElements = extensionPoint.getConfigurationElements();
 
 			for (IConfigurationElement configurationElement : configurationElements) {
-				AbstractURLStreamHandlerService svc = null;
-				String protocol = null;
-				try {
-					svc = (AbstractURLStreamHandlerService) configurationElement.createExecutableExtension(SERVICE_CLASS_ATTRIBUTE);
-					protocol = configurationElement.getAttribute(PROTOCOL_ATTRIBUTE);
-				}catch (CoreException e) {
-					log(e.getStatus());
-				}
-				if (svc != null && protocol != null) {
+				String protocol = configurationElement.getAttribute(PROTOCOL_ATTRIBUTE);
+				if (protocol != null) {
 					Hashtable properties = new Hashtable();
 					properties.put(URLConstants.URL_HANDLER_PROTOCOL, new String[] {protocol});
-					context.registerService(URLStreamHandlerService.class.getName(), svc, properties);
+					context.registerService(URLStreamHandlerService.class.getName(), new ProxyURLStreamHandlerService(configurationElement), properties);
 				}
 			}
 		}

--- a/framework/bundles/org.eclipse.ecf.filetransfer/src/org/eclipse/ecf/internal/filetransfer/ProxyURLStreamHandlerService.java
+++ b/framework/bundles/org.eclipse.ecf.filetransfer/src/org/eclipse/ecf/internal/filetransfer/ProxyURLStreamHandlerService.java
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors: Christoph Läubrich - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.internal.filetransfer;
+
+import java.io.IOException;
+import java.net.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.osgi.service.url.URLStreamHandlerService;
+import org.osgi.service.url.URLStreamHandlerSetter;
+
+public class ProxyURLStreamHandlerService implements URLStreamHandlerService {
+
+	private static final String SERVICE_CLASS_ATTRIBUTE = "serviceClass"; //$NON-NLS-1$
+
+	private final IConfigurationElement configurationElement;
+
+	private URLStreamHandlerService delegate;
+
+	public ProxyURLStreamHandlerService(IConfigurationElement configurationElement) {
+		this.configurationElement = configurationElement;
+	}
+
+	@Override
+	public URLConnection openConnection(URL u) throws IOException {
+		return getDelegate().openConnection(u);
+	}
+
+	@Override
+	public void parseURL(URLStreamHandlerSetter realHandler, URL u, String spec, int start, int limit) {
+		getDelegate().parseURL(realHandler, u, spec, start, limit);
+	}
+
+	@Override
+	public String toExternalForm(URL u) {
+		return getDelegate().toExternalForm(u);
+	}
+
+	@Override
+	public boolean equals(URL u1, URL u2) {
+		return getDelegate().equals(u1, u2);
+	}
+
+	@Override
+	public int getDefaultPort() {
+		return getDelegate().getDefaultPort();
+	}
+
+	@Override
+	public InetAddress getHostAddress(URL u) {
+		return getDelegate().getHostAddress(u);
+	}
+
+	@Override
+	public int hashCode(URL u) {
+		return getDelegate().hashCode(u);
+	}
+
+	@Override
+	public boolean hostsEqual(URL u1, URL u2) {
+		return getDelegate().hostsEqual(u1, u2);
+	}
+
+	@Override
+	public boolean sameFile(URL u1, URL u2) {
+		return getDelegate().sameFile(u1, u2);
+	}
+
+	synchronized URLStreamHandlerService getDelegate() {
+		if (delegate == null) {
+			try {
+				delegate = (URLStreamHandlerService) configurationElement.createExecutableExtension(SERVICE_CLASS_ATTRIBUTE);
+			} catch (CoreException e) {
+				throw new IllegalStateException("can't create executable extension", e); //$NON-NLS-1$
+			}
+		}
+		return delegate;
+	}
+
+}


### PR DESCRIPTION
Currently the activator loads the extension class what might trigger activation of bundles immediatly.

This changes to a more lazy aproach where the extension class is only loaded at frist use of the protocol.