### PR TITLE
Fix HttpClientRetrieveFileTransfer.isConnected()

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/provider/filetransfer/httpclientjava/HttpClientRetrieveFileTransfer.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/provider/filetransfer/httpclientjava/HttpClientRetrieveFileTransfer.java
@@ -755,7 +755,7 @@ public class HttpClientRetrieveFileTransfer extends AbstractRetrieveFileTransfer
 	}
 
 	protected boolean isConnected() {
-		return (httpResponse != null && !httpResponse.isCancelled());
+		return (httpRequest != null && httpResponse != null && !httpResponse.isCancelled());
 	}
 
 	/*

--- a/releng/org.eclipse.ecf.releng.repository/category.xml
+++ b/releng/org.eclipse.ecf.releng.repository/category.xml
@@ -45,6 +45,9 @@
    <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature.source" version="0.0.0">
       <category name="core sources"/>
    </feature>
+   <feature id="org.eclipse.ecf.filetransfer.httpclientjava.feature.source" version="0.0.0">
+      <category name="core sources"/>
+   </feature>
    <feature id="org.eclipse.ecf.filetransfer.httpclient45.feature.source" version="0.0.0">
       <category name="core sources"/>
    </feature>


### PR DESCRIPTION
The org.eclipse.ecf.filetransfer.httpclientjava implementation should not consider itself connected after a hard close.

The update site should provide sources for
org.eclipse.ecf.filetransfer.httpclientjava.

https://github.com/eclipse-equinox/p2/issues/301
https://github.com/eclipse-equinox/p2/pull/206