### PR TITLE
Adding Preferences for Request Header

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer/META-INF/MANIFEST.MF
@@ -10,7 +10,9 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.ecf;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.ecf.filetransfer;bundle-version="[5.0.0,6.0.0)",
- org.eclipse.equinox.registry;bundle-version="[3.0.0,4.0.0)"
+ org.eclipse.equinox.registry;bundle-version="[3.0.0,4.0.0)",
+ org.eclipse.core.runtime,
+ org.eclipse.ui
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.core.net.proxy;resolution:=optional,

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer/plugin.xml
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer/plugin.xml
@@ -36,5 +36,26 @@
             name="ecf.provider.filetransfer">
       </namespace>
    </extension>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.eclipse.ui.net.NetPreferences"
+            class="org.eclipse.ecf.provider.filetransfer.preferences.FileTransferPreferencePage"
+            id="org.eclipse.ecf.provider.filetransfer.preferences.FileTransferPreferencePage"
+            name="FileTransfer Preferences">
+      </page>
+   </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.eclipse.ecf.provider.filetransfer.preferences.PreferenceInitializer">
+      </initializer>
+   </extension>
+   <extension
+         point="org.eclipse.core.net.authenticator">
+      <authenticator
+            class="org.eclipse.ecf.provider.filetransfer.Authenticator1">
+      </authenticator>
+   </extension>
 
 </plugin>

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/FileTransferPreferencePage.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/FileTransferPreferencePage.java
@@ -1,0 +1,51 @@
+package org.eclipse.ecf.provider.filetransfer.preferences;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * This class represents a preference page that
+ * is contributed to the Preferences dialog. By 
+ * subclassing <samp>FieldEditorPreferencePage</samp>, we
+ * can use the field support built into JFace that allows
+ * us to create a page that is small and knows how to 
+ * save, restore and apply itself.
+ * <p>
+ * This page is used to modify preferences only. They
+ * are stored in the preference store that belongs to
+ * the main plug-in class. That way, preferences can
+ * be accessed directly via the preference store.
+ */
+
+public class FileTransferPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public FileTransferPreferencePage() {
+		super(GRID);
+		ScopedPreferenceStore scopedPreferenceStore = new ScopedPreferenceStore(InstanceScope.INSTANCE, String.valueOf(FrameworkUtil.getBundle(getClass()).getBundleId()));
+		setPreferenceStore(scopedPreferenceStore);
+		setDescription("This option allows you to configure a request header property/value pair.\n" //$NON-NLS-1$
+				+ " It is used during a connection request.\n\n"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Creates the field editors. Field editors are abstractions of
+	 * the common GUI blocks needed to manipulate various types
+	 * of preferences. Each field editor knows how to save and
+	 * restore itself.
+	 */
+	public void createFieldEditors() {
+
+		addField(new StringFieldEditor(PreferenceConstants.REQUEST_CONN_PROPERTY, "Request Connection:", getFieldEditorParent())); //$NON-NLS-1$
+		addField(new StringFieldEditor(PreferenceConstants.REQUEST_VALUE_PROPERTY, "Connection Value:", getFieldEditorParent())); //$NON-NLS-1$
+	}
+
+	public void init(IWorkbench workbench) {
+
+	}
+
+}

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/PreferenceConstants.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/PreferenceConstants.java
@@ -1,0 +1,11 @@
+package org.eclipse.ecf.provider.filetransfer.preferences;
+
+/**
+ * Constant definitions for plug-in preferences
+ */
+public class PreferenceConstants {
+
+	public static final String REQUEST_CONN_PROPERTY = "connectionPreference"; //$NON-NLS-1$
+	public static final String REQUEST_VALUE_PROPERTY = "connRequestValPreference"; //$NON-NLS-1$
+
+}

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/PreferenceInitializer.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer/src/org/eclipse/ecf/provider/filetransfer/preferences/PreferenceInitializer.java
@@ -1,0 +1,21 @@
+package org.eclipse.ecf.provider.filetransfer.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * Class used to initialize default preference values.
+ */
+public class PreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		ScopedPreferenceStore store = new ScopedPreferenceStore(InstanceScope.INSTANCE, String.valueOf(FrameworkUtil.getBundle(getClass()).getBundleId()));
+
+		store.setDefault(PreferenceConstants.REQUEST_CONN_PROPERTY, "Connection"); //$NON-NLS-1$
+		store.setDefault(PreferenceConstants.REQUEST_VALUE_PROPERTY, "close"); //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
This modification will allow subsequent Request header values to be set.  An example might be to access LDAP. In a customized corporate environment where PKI is used, the UrlConnection provider gets activated to check if there is an LDAP.
The first param is the name of the domain that is looked at, the second is the method in the LDAP that is checked.  The default in a non customized env the code is unused.