### PR TITLE
Increment the version of org.eclipse.ecf.remoteservice.servlet.feature

### DIFF
--- a/releng/features/org.eclipse.ecf.remoteservice.servlet.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.servlet.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.remoteservice.servlet.feature"
       label="ECF Remote Services Servlet API Feature"
-      version="1.0.400.qualifier"
+      version="1.0.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.remoteservice.servlet.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.servlet.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.ecf</groupId>
   <artifactId>org.eclipse.ecf.remoteservice.servlet.feature</artifactId>
-  <version>1.0.400-SNAPSHOT</version>
+  <version>1.0.500-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>


### PR DESCRIPTION
- This is needed so that baseline replacement doesn't try to replace the newly built feature which includes jakarta.servlet-api version 6.1.0 with the previous version that includes jakarta.servlet-api version 6.0.0.

https://github.com/eclipse/ecf/issues/116