### PR TITLE
Added support for usage of sslContextFactory.getInstance(protocol) and

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/provider/filetransfer/httpclientjava/HttpClientOptions.java
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/src/org/eclipse/ecf/provider/filetransfer/httpclientjava/HttpClientOptions.java
@@ -33,4 +33,13 @@ public interface HttpClientOptions {
 	int NTLM_PROXY_RESPONSE_CODE = 477;
 	String FORCE_NTLM_PROP = "org.eclipse.ecf.provider.filetransfer.httpclient4.options.ForceNTLMProxy"; //$NON-NLS-1$
 
+	/**
+	 * @since 2.0
+	 */
+	String HTTPCLIENT_SSLCONTEXT_PROTOCOL = System.getProperty("org.eclipse.ecf.provider.filetransfer.httpclient.sslcontext.protocol"); //$NON-NLS-1$
+
+	/**
+	 * @since 2.0
+	 */
+	String HTTPCLIENT_SSLCONTEXT_PROVIDER = System.getProperty("org.eclipse.ecf.provider.filetransfer.httpclient.sslcontext.provider"); //$NON-NLS-1$
 }

--- a/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
+++ b/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
@@ -37,7 +37,6 @@
       <unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.httpclient.win" version="0.0.0"/>
       <unit id="org.apache.log4j" version="0.0.0"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
       <unit id="org.apiguardian.api" version="0.0.0"/>
       <unit id="org.bndtools.headless.build.plugin.gradle" version="0.0.0"/>
       <unit id="org.bndtools.templates.template" version="0.0.0"/>


### PR DESCRIPTION
sslContextFactory.getInstance(protocol,provider) in creation of HttpClient.Builder in ECFHttpClientFactory.newClient()