### PR TITLE
remove x-installation:=greedy from package import

### DIFF
--- a/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Export-Package: org.eclipse.ecf.core;version="3.0.0",
  org.eclipse.ecf.core.util.reflection;version="2.3.0",
  org.eclipse.ecf.internal.core;x-internal:=true
 Import-Package: org.eclipse.core.runtime.jobs,
- org.eclipse.equinox.concurrent.future;version="[1.0.0,2.0.0)";x-installation:=greedy,
+ org.eclipse.equinox.concurrent.future;version="[1.0.0,2.0.0)",
  org.osgi.framework;version="[1.3.0,2.0.0)",
  org.osgi.service.log;version="[1.3.0,2.0.0)",
  org.osgi.util.tracker;version="[1.3.2,2.0.0)"


### PR DESCRIPTION
x-installation:=greedy is only effective for optional bundles/packaged.

`org.eclipse.equinox.concurrent.future` is a package import and it is not optional so it looks quite pointless to have this directive there.