### PR TITLE
Add a lower version bound for OSGi API import

### DIFF
--- a/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
@@ -23,9 +23,9 @@ Export-Package: org.eclipse.ecf.core;version="3.0.0",
  org.eclipse.ecf.internal.core;x-internal:=true
 Import-Package: org.eclipse.core.runtime.jobs,
  org.eclipse.equinox.concurrent.future;version="[1.0.0,2.0.0)",
- org.osgi.framework;version="[1.3.0,2.0.0)",
+ org.osgi.framework;version="[1.6.0,2)",
  org.osgi.service.log;version="[1.3.0,2.0.0)",
- org.osgi.util.tracker;version="[1.3.2,2.0.0)"
+ org.osgi.util.tracker;version="[1.5.0,2)"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.0.0,4.0.0)";resolution:=optional,
  org.eclipse.ecf.identity;visibility:=reexport

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5.win32/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Import-Package: org.apache.hc.client5.http;version="[5.1.3,6.0.0)",
  org.eclipse.ecf.filetransfer;version="[5.0.0,6.0.0)",
  org.eclipse.ecf.internal.provider.filetransfer.httpclient5;version="[1.0.0,2.0.0)",
  org.eclipse.ecf.provider.filetransfer.httpclient5;version="[1.0.0,2.0.0)",
- org.osgi.framework;version="[1.3.0,2.0.0)",
+ org.osgi.framework;version="[1.5.0,2)",
  org.osgi.service.component.annotations;version="[1.2.0,2.0.0)";resolution:=optional
 Eclipse-PlatformFilter: (osgi.os=win32)
 Service-Component: OSGI-INF/services/*.xml

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
@@ -55,7 +55,7 @@ Import-Package: org.apache.hc.client5.http;version="[5.1.3,6.0.0)",
  org.eclipse.ecf.provider.filetransfer.util;version="3.2.0",
  org.eclipse.osgi.service.debug;version="1.2.0",
  org.eclipse.osgi.util;version="1.1.0",
- org.osgi.framework,
+ org.osgi.framework;version="[1.6.0,2)",
  org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.log;version="1.5.0",
  org.osgi.util.tracker;version="1.5.2"

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Import-Package: javax.net.ssl,
  org.eclipse.ecf.provider.filetransfer.util;version="3.2.0",
  org.eclipse.osgi.service.debug;version="1.2.0",
  org.eclipse.osgi.util;version="1.1.0",
- org.osgi.framework,
+ org.osgi.framework;version="[1.6.0,2)",
  org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.log;version="1.5.0",
  org.osgi.util.tracker;version="1.5.2"


### PR DESCRIPTION
I checked ECF for lower version bound problems with new [Tycho version check ](https://github.com/eclipse-tycho/tycho/blob/main/RELEASE_NOTES.md#new-check-dependencies-mojo) and found these issues

## ecf

Import-Package `org.osgi.framework [1.3.0,2.0.0)` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#registerService (Ljava/lang/Class;Ljava/lang/Object;Ljava/util/Dictionary;)Lorg/osgi/framework/ServiceRegistration;` referenced by:
- org.eclipse.ecf.internal.core.ECFPlugin
- org.eclipse.ecf.internal.core.ECFPlugin$5 

Import-Package `org.osgi.framework [1.3.0,2.0.0)` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#registerService (Ljava/lang/Class;Ljava/lang/Object;Ljava/util/Dictionary;)Lorg/osgi/framework/ServiceRegistration;` referenced by:
- org.eclipse.ecf.internal.core.ECFPlugin
- org.eclipse.ecf.internal.core.ECFPlugin$5 

Import-Package `org.osgi.util.tracker [1.3.2,2.0.0)` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.4.2` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker#<init> (Lorg/osgi/framework/BundleContext;Ljava/lang/Class;Lorg/osgi/util/tracker/ServiceTrackerCustomizer;)V` referenced by:
- org.eclipse.ecf.core.security.ECFSSLContextFactory 

Import-Package `org.osgi.util.tracker [1.3.2,2.0.0)` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.3.3` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker#<init> (Lorg/osgi/framework/BundleContext;Ljava/lang/Class;Lorg/osgi/util/tracker/ServiceTrackerCustomizer;)V` referenced by:
- org.eclipse.ecf.core.security.ECFSSLContextFactory 

Import-Package `org.osgi.util.tracker [1.3.2,2.0.0)` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.3.3` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker#getTracked ()Ljava/util/SortedMap;` referenced by:
- org.eclipse.ecf.core.security.ECFSSLContextFactory 

Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]
Suggested lower version for package `org.osgi.util.tracker` is `1.5.0` out of [`1.3.3`, `1.4.0`, `1.4.2`, `1.5.0`, `1.5.1`, `1.5.2`, `1.5.3`, `1.5.4`]

## httpclient5

Import-Package `org.osgi.framework 0.0.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference (Ljava/lang/Class;)Lorg/osgi/framework/ServiceReference;` referenced by:
- org.eclipse.ecf.internal.provider.filetransfer.httpclient5.Activator 

Import-Package `org.osgi.framework 0.0.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference (Ljava/lang/Class;)Lorg/osgi/framework/ServiceReference;` referenced by:
- org.eclipse.ecf.internal.provider.filetransfer.httpclient5.Activator 

Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]

## httpclient5.win32

Import-Package `org.osgi.framework [1.3.0,2.0.0)` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/FrameworkUtil#getBundle (Ljava/lang/Class;)Lorg/osgi/framework/Bundle;` referenced by:
- org.eclipse.ecf.internal.provider.filetransfer.httpclient5.win32.Win32HttpClientConfigurationModifier 

Suggested lower version for package `org.osgi.framework` is `1.5.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]

## httpclientjava

Import-Package `org.osgi.framework 0.0.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference (Ljava/lang/Class;)Lorg/osgi/framework/ServiceReference;` referenced by:
- org.eclipse.ecf.internal.provider.filetransfer.httpclientjava.Activator 

Import-Package `org.osgi.framework 0.0.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.20.0.v20240509-1421`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference (Ljava/lang/Class;)Lorg/osgi/framework/ServiceReference;` referenced by:
- org.eclipse.ecf.internal.provider.filetransfer.httpclientjava.Activator 

Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]